### PR TITLE
Ubuntu 14.04 specific install instructions

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -3,3 +3,11 @@
   apt:
     name: "letsencrypt={{ certbot_letsencrypt_version }}"
     state: present
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release != 'trusty'
+
+- name: letsencrypt install ubuntu 14.04
+  get_url:
+    url: https://dl.eff.org/certbot-auto
+    dest: /usr/bin/letsencrypt
+    mode: 0655
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'


### PR DESCRIPTION
The letsencrypt package is not in the official repositories for
Ubuntu 14.04. Hence install via the url download method.