### PR TITLE
Install certbot from ppa:certbot/certbot

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,7 @@
+certbot_certonly: true
 certbot_create_certs: false
 certbot_renew_certs_minute: 12,45
 certbot_renew_certs_hour: 8
 certbot_renew_certs_month: '*/1'
 certbot_renew_certs_weekday: 1
-certbot_waitfor_port_seconds: 3
-certbot_webserver_installed: "nginx"
-certbot_letsencrypt_version: "0.4.1-1"
+certbot_version: "0.25.*"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: restart certbot
+  command: certbot --nginx --agree-tos -m {{ certbot_mail_address }} -n -d {{ site_name }}
+  when: certbot_create_certs
+

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,13 +1,15 @@
 ---
-- name: letsencrypt installed
-  apt:
-    name: "letsencrypt={{ certbot_letsencrypt_version }}"
-    state: present
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release != 'trusty'
+- name: Install Certbot on Ubuntu
+  block:
+    - name: Certbot PPA
+      apt_repository:
+        repo: "ppa:certbot/certbot"
+        state: present
+        update_cache: no
 
-- name: letsencrypt install ubuntu 14.04
-  get_url:
-    url: https://dl.eff.org/certbot-auto
-    dest: /usr/bin/letsencrypt
-    mode: 0655
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'
+    - name: Install certbot nginx plugin
+      apt:
+        name: "python-certbot-nginx={{ certbot_version }}"
+        state: present
+        update_cache: yes
+  when: ansible_distribution == 'Ubuntu'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,25 +2,11 @@
 - include_tasks: debian.yml
   when: ansible_os_family == 'Debian'
 
-- name: Stop webserver
-  service:
-    name: "{{ certbot_webserver_installed }}"
-    state: stopped
-  ignore_errors: yes
-
-- name: Check whether port 80 is available
-  wait_for:
-    port: 80
-    state: stopped
-    timeout: "{{ certbot_waitfor_port_seconds }}"
-
-- name: Create certs
-  command: letsencrypt certonly --standalone -d {{ site_name }} -m {{ certbot_mail_address }} --agree-tos --noninteractive --text
+- name: Create certs only
+  command: certbot certonly --nginx --agree-tos -m {{ certbot_mail_address }} -n -d {{ site_name }}
   args:
     creates: "{{ certbot_crt }}"
   when: certbot_create_certs
-
-- include_tasks: copy-files.yml
 
 - name: Renew certs every month
   cron:
@@ -29,11 +15,5 @@
     hour: "{{ certbot_renew_certs_hour }}"
     month: "{{ certbot_renew_certs_month }}"
     weekday: "{{ certbot_renew_certs_weekday }}"
-    job: /usr/bin/letsencrypt renew
+    job: /usr/bin/certbot renew -q
   when: certbot_create_certs
-
-- name: Start webserver
-  service:
-    name: "{{ certbot_webserver_installed }}"
-    state: started
-  ignore_errors: yes


### PR DESCRIPTION
- Creates a certificate using the nginx plugin for certbot. 
- Adds a handler, `restart certbot`, that will configure nginx site-enabled site with the appropriate ssl keys. Should be triggered by the task that wants to apply the configuration.
- The `certbot renew` command auto renews certificates for all domains configured.