### PR TITLE
Removes certbot_create_certs From Autorenewal Reqs

### DIFF
--- a/tasks/autorenew-cron.yml
+++ b/tasks/autorenew-cron.yml
@@ -7,6 +7,4 @@
     month: "{{ certbot_renew_certs_month }}"
     weekday: "{{ certbot_renew_certs_weekday }}"
     job: "{{ certbot_autorenew_command }}"
-  when:
-    - certbot_create_certs
-    - certbot_plugin == "standalone"
+  when: certbot_plugin == "standalone"

--- a/tasks/autorenew-systemd.yml
+++ b/tasks/autorenew-systemd.yml
@@ -17,6 +17,4 @@
       daemon_reload: yes
       enabled: yes
       state: restarted
-  when:
-    - certbot_create_certs
-    - certbot_plugin == "standalone"
+  when: certbot_plugin == "standalone"


### PR DESCRIPTION
Since setting certbot_create_certs to false should technically only
prevent the role from trying to create certificates and not affect
whether the auto-renewal scripts/cron should be installed on the server.

This commit removes certbot_create_certs from the list of variables
checked before installing autorenewal.

Signed-off-by: Jason Rogena <jason@rogena.me>