### PR TITLE
Add ability to automatically redirect all HTTP traffic to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The email address that receives notifications when certs are going to be expired
 
 - Setting `certbot_install_cert:true` modifies the virtual site file to add directives for including ssl certificate, key and default Let's Encrypt SSL configuration
 
-- Setting `certbot_redirect_http:true` will modify the virtual site file to add dirctives to redirect all http traffic to https.
+- Setting `certbot_redirect_http:true` will modify the virtual site file to add dirctives to redirect all HTTP traffic to HTTPS. HTTPS configuration (including supported TLS versions, whether to include the HSTS header, and which cipher suits are supported) is done by the certbot package.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ By default, neither certs will be created, nor renewed.
 
 The email address that receives notifications when certs are going to be expired is empty by default and needs to be set otherwise the run will fail.
 
+**Note on Certbot plugins that modify the virtual site files**
+
+- Setting `certbot_install_cert:true` modifys the virtual site file to add directives for including ssl certificate, key and default letsencrypt SSL configuration
+
+- Setting `certbot_redirect_http:true` will modify the virtual site file to add dirctives to redirect all http traffic to https.
+
 ## Dependencies
 
 None.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The email address that receives notifications when certs are going to be expired
 
 **Note on Certbot plugins that modify the virtual site files**
 
-- Setting `certbot_install_cert:true` modifys the virtual site file to add directives for including ssl certificate, key and default letsencrypt SSL configuration
+- Setting `certbot_install_cert:true` modifies the virtual site file to add directives for including ssl certificate, key and default Let's Encrypt SSL configuration
 
 - Setting `certbot_redirect_http:true` will modify the virtual site file to add dirctives to redirect all http traffic to https.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ By default, neither certs will be created, nor renewed.
     certbot_package: "certbot" # can be certbot, python-certbot-nginx, python-certbot-apache
     certbot_plugin: "standalone" # can be apache, webroot, nginx or standalone
     certbot_install_cert: false # false will use certonly, true will use the plugin configured to add the ssl configs to the sites config.
+    certbot_redirect_http: false # True will redirect all http traffic to https
     certbot_site_names: ["example.com","www.example.com"] # List of domain names to get certificates for.
     certbot_cert_name: {{ certbot_site_names[0] }}
     certbot_renew_prehook: "service {{ certbot_webserver_installed }} stop"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ certbot_letsencrypt_version: "0.4.1-1"
 certbot_package: "certbot" # can be certbot, python-certbot-nginx, python-certbot-apache
 certbot_plugin: "standalone" # can be apache, webroot, nginx or standalone
 certbot_install_cert: false # false will use certonly, true will use the plugin configured to add the ssl configs to the sites congig.
+certbot_redirect_http: false # True will redirect all http traffic to https
 certbot_renew_prehook: "/usr/sbin/service {{ certbot_webserver_installed }} stop"
 certbot_renew_posthook: "/usr/sbin/service {{ certbot_webserver_installed }} start"
 certbot_cert_name: "{{ certbot_site_names[0] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
   when: certbot_plugin == "standalone"
 
 - name: Create and install cert using {{ certbot_plugin }} plugin
-  command: "certbot --{{ certbot_plugin }} {{ (certbot_install_cert) | ternary('','certonly') }} -d {{ certbot_site_names | join(' -d ') }} -m {{ certbot_mail_address }} --agree-tos --noninteractive --text --cert-name {{ certbot_cert_name }}"
+  command: "certbot --{{ certbot_plugin }} {{ (certbot_install_cert) | ternary('','certonly') }} {{ (certbot_redirect_http) | ternary('--redirect','') }} -d {{ certbot_site_names | join(' -d ') }} -m {{ certbot_mail_address }} --agree-tos --noninteractive --text --cert-name {{ certbot_cert_name }}"
 
 - include_tasks: copy-files.yml
 


### PR DESCRIPTION
For setups that certbot installs/modifies the virtual site file,
certbot can add a redirect directive to the virtual site file to
redirect all http traffic to https

Signed-off-by: Morris Mukiri <morrismukiri@gmail.com>