### PR TITLE
Retry Creating Cert if Task Fails

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,8 @@
 
 - name: Create and install cert using {{ certbot_plugin }} plugin
   command: "certbot --{{ certbot_plugin }} {{ (certbot_install_cert) | ternary('','certonly') }} {{ (certbot_redirect_http) | ternary('--redirect','') }} -d {{ certbot_site_names | join(' -d ') }} -m {{ certbot_mail_address }} --agree-tos --noninteractive --text --cert-name {{ certbot_cert_name }}"
+  retries: 3
+  delay: 5
 
 - include_tasks: copy-files.yml
 


### PR DESCRIPTION
Sometimes the "Create and install cert" task fails because there's
another instance of certbot running on the host. This might happen if
certbot had already been setup on the host and it was, at the time of
running the task, running maybe to renew certs.

Retry running the task three times (spaced out witha delay of 5 seconds).

Signed-off-by: Jason Rogena <jason@rogena.me>