### PR TITLE
Update tasks to support installing on Ubuntu 20

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ certbot_renew_certs_systemd_rand_sec: 3600
 certbot_renew_method: systemd
 certbot_waitfor_port_seconds: 3
 certbot_webserver_installed: "nginx"
-certbot_letsencrypt_version: "0.4.1-1"
+certbot_letsencrypt_version: "0.40.0"
 certbot_package: "certbot" # can be certbot, python-certbot-nginx, python-certbot-apache
 certbot_plugin: "standalone" # can be apache, webroot, nginx or standalone
 certbot_install_cert: false # false will use certonly, true will use the plugin configured to add the ssl configs to the sites congig.

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -11,6 +11,7 @@
     state: present
   with_items:
     - "ppa:certbot/certbot"
+  when: version_compare("{{ ansible_distribution_release }}", "<=", "18.04")
 
 - name: Certbot | Install package
   become: true


### PR DESCRIPTION
update default letsencrypt version and only add certbot PPA for 18.04 and below